### PR TITLE
bugfix: copy base product image url when a variant has a placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.1.5] 2023-01-9
+
+### Fixed
+
+- Add logic to set default image url (base product image) when a variant has not a selected image

--- a/Model/Api/Catalog/Product/ConfigurableProductBuilder.php
+++ b/Model/Api/Catalog/Product/ConfigurableProductBuilder.php
@@ -23,11 +23,13 @@ class ConfigurableProductBuilder extends Product implements ProductInterface{
       ->getTypeInstance()
       ->getUsedProductAttributes($productModel);
 
+    $productArray["imageUrl"] = $this->getImage($productModel);
+    
     $highestPrice = 0;
     $variantsArray = array();
     $optionsArray = array();
     $childProducts = $productModel->getTypeInstance()
-        ->getUsedProducts($productModel);
+    ->getUsedProducts($productModel);
     foreach ($childProducts as $child)
     {
         //Si la variante no tiene stock, la ignoramos.
@@ -65,7 +67,7 @@ class ConfigurableProductBuilder extends Product implements ProductInterface{
                 }
             }
         }
-        $imageUrl = $this->getImage($child);
+        $imageUrl = $this->getImage($child)?? $productArray['imageUrl'];
         $childPrice = (float)number_format($child->getFinalPrice() , 2, ",", ""); 
         $childOriginalPrice = (float)number_format($child->getPriceInfo()->getPrice('regular_price')->getValue() , 2, ",", "");
         if ($childOriginalPrice > $highestPrice) {
@@ -98,7 +100,6 @@ class ConfigurableProductBuilder extends Product implements ProductInterface{
     $productArray["variantOptions"] = $optionsArray;
     $configProductPrice = (float)number_format($child->getPriceInfo()->getPrice('regular_price')->getValue() , 2, ",", "");
     $productArray["price"] =  ($configProductPrice == 0 ) ? $highestPrice : $configProductPrice ;
-    $productArray["imageUrl"] = $this->getImage($productModel);
 
     return $productArray;
   }

--- a/Model/Api/Catalog/Product/Product.php
+++ b/Model/Api/Catalog/Product/Product.php
@@ -30,11 +30,18 @@ abstract class Product
 
   protected function getImage($product)
   {
-    $imageUrl = $this
-      ->imageHelper
-      ->init($product, 'product_page_image')->setImageFile($product->getImage()) // image,small_image,thumbnail
-      ->getUrl();
-    return $imageUrl;
+    $image = $product->getImage();
+
+    if ($image && $image != 'no_selection') {
+      $imageUrl = $this
+        ->imageHelper
+        ->init($product, 'product_page_image')
+        ->setImageFile($image) // image,small_image,thumbnail
+        ->getUrl();
+      return $imageUrl;
+    } else {
+      return null;
+    }
   }
 
   protected function getStock($productModel)

--- a/Model/Api/Version.php
+++ b/Model/Api/Version.php
@@ -4,7 +4,7 @@ namespace Gojiraf\Gojiraf\Model\Api;
 
 
 class Version{
-    private $moduleVersion = '1.1.4';
+    private $moduleVersion = '1.1.5';
 
     // /rest/V1/gojiraf/version
     public function getVersion(){

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ It includes functions that automatically process guests-carts (previously genera
 
 ## How to install
 
-- Require the project througt composer:
+- Require the project through composer:
 
 ``` bash
 composer require gojiraf/live-shopp-mg-module
 ```
 
-- Install the module on to Magento:
+- Install the module in Magento:
 
 ``` bash
 php bin/magento setup:upgrade
@@ -56,7 +56,7 @@ It implies to generate an access token and give it to our support area, who will
 
 #### Automatic integration
 
-Our integration service can automatically create your Live Shopping account and request the access token to Magento. However, it is not the most recommended option right now, due to some unexpected behaviors, and because is suitable only to one-site systems.
+Our integration service can automatically create your Live Shopping account and request the access token to Magento. However, it is not the most recommended option right now, due to some unexpected behaviors, and because it is suitable only to one-site systems.
 If you still want to try it, the steps are very simple. After install the Gojiraf's module, you will find a "ready-to-go" integration in your panel.
 
 **Steps:**


### PR DESCRIPTION
Changed logic for getting product variant image url. Now, when a variant hasn't an image (this is, has a placeholder), the module takes the image url from the base product.
Thus, when there is a placeholder in Magento, in Live Shopping the variant is not shown with an empty image.